### PR TITLE
Enhance data table editor with editing, history and download options

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
                             hover:file:opacity-90 cursor-pointer
                         "/>
                         <button id="clear-data-btn" class="themed-button px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 hidden">Clear</button>
+                        <button id="load-session-btn" class="themed-button px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300">Load Session</button>
                     </div>
                     <p id="file-name" class="text-sm text-[--text-secondary] mt-2"></p>
                 </div>
@@ -139,6 +140,12 @@
                 <!-- Step 2: View and Edit Data -->
                 <div id="table-section" class="hidden">
                      <h2 class="text-lg font-semibold mb-2 flex items-center"><span class="bg-[--accent-color] text-white rounded-full h-6 w-6 text-sm flex items-center justify-center mr-3">2</span>Your Data</h2>
+                    <div class="flex flex-wrap items-center mb-4 gap-2">
+                        <input id="filter-input" type="text" placeholder="Filter rows..." class="px-3 py-2 rounded-lg border focus:ring-2 focus:ring-[--accent-color] focus:border-[--accent-color]" />
+                        <button id="add-row-btn" class="themed-button px-4 py-2 bg-[--accent-color] text-white rounded-lg font-semibold hover:bg-[--accent-hover]">Add Row</button>
+                        <button id="undo-btn" class="themed-button px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300" disabled>Undo</button>
+                        <button id="redo-btn" class="themed-button px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300" disabled>Redo</button>
+                    </div>
                     <div id="table-container" class="table-container rounded-lg">
                         <table id="csv-table" class="min-w-full">
                             <!-- Table content will be generated here -->
@@ -165,10 +172,16 @@
                 <!-- Step 4: Download -->
                 <div id="download-section" class="hidden">
                     <h2 class="text-lg font-semibold mb-2 flex items-center"><span class="bg-[--accent-color] text-white rounded-full h-6 w-6 text-sm flex items-center justify-center mr-3">4</span>Download Result</h2>
-                    <button id="download-btn" class="themed-button w-full sm:w-auto px-6 py-3 bg-[--success-color] text-white rounded-lg font-semibold hover:bg-[--success-hover] flex items-center justify-center space-x-2 shadow-md">
-                        <i class="fa-solid fa-download"></i>
-                        <span>Download New CSV</span>
-                    </button>
+                    <div class="flex flex-col sm:flex-row gap-4">
+                        <button id="download-csv-btn" class="themed-button w-full sm:w-auto px-6 py-3 bg-[--success-color] text-white rounded-lg font-semibold hover:bg-[--success-hover] flex items-center justify-center space-x-2 shadow-md">
+                            <i class="fa-solid fa-file-csv"></i>
+                            <span>Download as CSV</span>
+                        </button>
+                        <button id="download-json-btn" class="themed-button w-full sm:w-auto px-6 py-3 bg-[--success-color] text-white rounded-lg font-semibold hover:bg-[--success-hover] flex items-center justify-center space-x-2 shadow-md">
+                            <i class="fa-solid fa-file-code"></i>
+                            <span>Download as JSON</span>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -743,6 +743,9 @@ table th {
     color: var(--text-primary);
     border-bottom: 2px solid var(--glass-border);
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }
 
 table td {
@@ -753,6 +756,38 @@ table td {
 
 table tr:hover td {
     background-color: var(--glass-border);
+}
+
+/* Editing state */
+.editing-cell {
+    outline: 2px solid var(--accent-color);
+    box-shadow: 0 0 8px var(--accent-color);
+}
+
+.editing-cell input {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    outline: none;
+}
+
+/* Delete row button visibility */
+.delete-row-btn {
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+tr:hover .delete-row-btn {
+    opacity: 1;
+}
+
+/* Text inputs */
+input[type="text"] {
+    background-color: var(--input-bg);
+    border: 1px solid var(--input-border);
+    color: var(--text-primary);
+    transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 input[type="file"]::file-selector-button {


### PR DESCRIPTION
## Summary
- Enable in-place editing, row management, sorting/filtering and CSV/JSON exports in the Data Table Editor
- Persist table sessions with undo/redo history and localStorage support
- Warn against exposing API keys in public code and adopt custom modal alerts

## Testing
- `npm test` (fails: missing package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6890da9c2b7c832b889bad4c4790e265