### PR TITLE
chore: update OpenRouter API key

### DIFF
--- a/script.js
+++ b/script.js
@@ -591,7 +591,7 @@ async function handleAiRequest() {
         // DO NOT expose real API keys in any public-facing project.
         // Hardcoding an API key in client-side code allows anyone to steal it.
         // This key is provided only for local testing at the user's request.
-        const openRouterApiKey = "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";
+        const openRouterApiKey = "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";
         
         const apiUrl = `https://openrouter.ai/api/v1/chat/completions`;
         


### PR DESCRIPTION
## Summary
- replace hardcoded OpenRouter API key with new value

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890de33e24c832bb949a1fa71ec4b1b