### PR TITLE
feat: proxy AI requests through serverless endpoint

### DIFF
--- a/api-proxy.js
+++ b/api-proxy.js
@@ -1,0 +1,72 @@
+const http = require('http');
+
+async function handler(req, res) {
+    if (req.method !== 'POST') {
+        res.statusCode = 405;
+        res.setHeader('Content-Type', 'application/json');
+        return res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    }
+
+    let body = '';
+    req.on('data', chunk => {
+        body += chunk;
+    });
+    req.on('end', async () => {
+        try {
+            const { userPrompt, tableData } = JSON.parse(body || '{}');
+            if (!userPrompt || !Array.isArray(tableData)) {
+                res.statusCode = 400;
+                res.setHeader('Content-Type', 'application/json');
+                return res.end(JSON.stringify({ error: 'Invalid request body' }));
+            }
+
+            const systemPrompt = 'You are an intelligent data editing assistant. Your task is to modify the provided JSON dataset based on the user\'s instruction. You must return ONLY the updated dataset in a valid JSON array-of-objects format. Do not add any commentary, explanations, markdown formatting, or any text outside of the JSON structure.';
+            const fullUserPrompt = `User instruction: "${userPrompt}"\n\nInput Dataset:\n${JSON.stringify(tableData, null, 2)}`;
+
+            const apiKey = process.env.MYY_SECRET_SHH;
+            if (!apiKey) {
+                throw new Error('Missing OpenRouter API key');
+            }
+
+            const payload = {
+                model: 'anthropic/claude-3.5-sonnet',
+                messages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: fullUserPrompt }
+                ]
+            };
+
+            const apiResponse = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${apiKey}`
+                },
+                body: JSON.stringify(payload)
+            });
+
+            if (!apiResponse.ok) {
+                const errorDetail = await apiResponse.text();
+                throw new Error(errorDetail || apiResponse.statusText);
+            }
+
+            const data = await apiResponse.json();
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify(data));
+        } catch (err) {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: err.message }));
+        }
+    });
+}
+
+if (require.main === module) {
+    const port = process.env.PORT || 3000;
+    http.createServer(handler).listen(port, () => {
+        console.log(`API proxy listening on port ${port}`);
+    });
+} else {
+    module.exports = handler;
+}

--- a/script.js
+++ b/script.js
@@ -583,38 +583,18 @@ async function handleAiRequest() {
     }
     toggleLoading(true);
 
-    const systemPrompt = `You are an intelligent data editing assistant. Your task is to modify the provided JSON dataset based on the user's instruction. You must return ONLY the updated dataset in a valid JSON array-of-objects format. Do not add any commentary, explanations, markdown formatting, or any text outside of the JSON structure.`;
-    const fullUserPrompt = `User instruction: "${userPrompt}"\n\nInput Dataset:\n${JSON.stringify(tableData, null, 2)}`;
-    
     try {
-        // !!! SECURITY WARNING !!!
-        // DO NOT expose real API keys in any public-facing project.
-        // Hardcoding an API key in client-side code allows anyone to steal it.
-        // This key is provided only for local testing at the user's request.
-        const openRouterApiKey = "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";
-        
-        const apiUrl = `https://openrouter.ai/api/v1/chat/completions`;
-        
-        const payload = {
-            model: "anthropic/claude-3.5-sonnet",
-            messages: [
-                { "role": "system", "content": systemPrompt },
-                { "role": "user", "content": fullUserPrompt }
-            ]
-        };
-
-        const response = await fetch(apiUrl, {
+        const response = await fetch('/api-proxy', {
             method: 'POST',
-            headers: { 
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${openRouterApiKey}`
+            headers: {
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify(payload)
+            body: JSON.stringify({ userPrompt, tableData })
         });
 
         if (!response.ok) {
-            const errorDetail = await response.json();
-            throw new Error(`API request failed: ${errorDetail?.error?.message || response.statusText}`);
+            const errorDetail = await response.json().catch(() => ({}));
+            throw new Error(`Proxy request failed: ${errorDetail?.error || response.statusText}`);
         }
 
         const result = await response.json();


### PR DESCRIPTION
## Summary
- add serverless API proxy that reads user prompts and forwards them to OpenRouter using secret key
- update client-side AI handler to call proxy instead of OpenRouter directly

## Testing
- `node api-proxy.js & sleep 1; kill $!`
- `node -e "new Function(require('fs').readFileSync('api-proxy.js','utf8'))"`
- `node -e "new Function(require('fs').readFileSync('script.js','utf8'))"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e3786bcc832bad6fb1085caf78d9